### PR TITLE
Increase range pkg/args allowed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.9+1
+
+- Support `args: ">=0.13.7 <2.0.0"`.
+
 ## 0.1.9
 
 - Remove `package:func` dependency.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: pwa
-version: 0.1.9
+version: 0.1.9+1
 author: Istvan Soos <istvan.soos@gmail.com>
 description: Progressive Web App library
 
@@ -9,7 +9,7 @@ environment:
   sdk: ">=1.21.0 <2.0.0"
 
 dependencies:
-  args: ">=0.13.7 <1.0.0"
+  args: ">=0.13.7 <2.0.0"
   dart_style: ">=0.2.16 <1.1.0"
   glob: ^1.1.3
   service_worker: ^0.1.0


### PR DESCRIPTION
... otherwise it's not usable with `angular_compiler`, which requires `>=1.3.0`.